### PR TITLE
Fix false positive

### DIFF
--- a/test/table_process_one_test.exs
+++ b/test/table_process_one_test.exs
@@ -4,6 +4,8 @@ defmodule TableProcessOneTest do
   test "send a ping, process dies" do
     pid = TableProcessOne.start
 
+    :timer.sleep(1)
+
     assert true == Process.alive?(pid)
 
     send(pid, :ping)


### PR DESCRIPTION
Given I start the exercise by spawning a process with an anonymous function in the module `TableProcessOne#start`, like so:

```elixir
  def start do
    # insert spawn here
    spawn(fn -> "anonymous" end)
  end
```

Then I run the test `mix test test/table_process_one_test.exs`
Then test passes

This is misleading, because I did not spawn the process with the `TableProcessOne#ping` function, which is the intention of the test. Adding the `:timer.sleep(1)` gives the process enough time to die, and fail the test.